### PR TITLE
Correction de la description des définitions des sorts SPPR104 et SPWI202

### DIFF
--- a/bg2eetrans/tob.tph
+++ b/bg2eetrans/tob.tph
@@ -12162,7 +12162,7 @@ Historique*/
 	STRING_SET ~12157~ @12157	// Very likely 99.9 
 	STRING_SET ~12158~ @12158	// Very likely 99.9 
 	STRING_SET ~12159~ @12159	// Very likely 95.9 
-	STRING_SET ~12160~ @12219	// manuel MODIFIER
+	STRING_SET ~12160~ @12160	// correction Freddy : rétablissement de la définition du sort divin Détection du mal (SPPR104)
 	STRING_SET ~12161~ @12161	// manuel 
 	STRING_SET ~12162~ @12162	// manuel 
 	STRING_SET ~12163~ @12163	// Very likely 91.6 
@@ -12221,7 +12221,7 @@ Historique*/
 	STRING_SET ~12216~ @12216	// manuel ajout
 	STRING_SET ~12217~ @12217	// manuel ajout
 	STRING_SET ~12218~ @12118	// manuel ajout 
-	STRING_SET ~12219~ @12119	// manuel ajout 
+	STRING_SET ~12219~ @12219	// correction Freddy : rétablissement de la définition du sort profane Détection du mal (SPWI202)
 	STRING_SET ~12220~ @12220	// manuel ajout 
 	STRING_SET ~12221~ @12221	// manuel ajout
 	STRING_SET ~12222~ @12222	// manuel ajout


### PR DESCRIPTION
Correction de la description des définitions des sorts divin (SPPR104) et profane (SPWI202) Détection du mal signalée par Kyber

Source : https://www.baldursgateworld.fr/lacouronne/traduction-participative-de-bg2ee/31539-signalement-de-defaut-de-traduction-ou-d-absence-anormale-de-traduction.html#post461260
Mauvaise affectation des références 12160 et 12219.

Signed-off-by: GwendolyneFreddy <gwendolyne.freddy@gmail.com>